### PR TITLE
feat: replace mypy with pyright

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -12,6 +12,7 @@ jobs:
     uses: BlindfoldedSurgery/actions-python/.github/workflows/lint.yml@v5
     with:
       build-tool: uv
+      type-checker: pyright
       python-version: '3.13'
 
   integration-test:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ check: lint test
 lint:
 	uv run ruff format src/
 	uv run ruff check --fix --show-fixes src/
-	uv run mypy src/
+	uv run pyright src/
 
 .PHONY: test
 test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-    "mypy ==1.16.*",
+    "pyright ==1.1.401",
     "pytest >=8.0.0, <9.0.0",
     "pytest-mock >=3.11.1, <4.0.0",
     "pytest-recording >=0.13.0, <0.14.0",
@@ -49,24 +49,8 @@ markers = [
     "integration",
 ]
 
-[tool.mypy]
-strict = true
-check_untyped_defs = true
-plugins = ["pydantic.mypy"]
-
-[[tool.mypy.overrides]]
-module = "tests.*"
-check_untyped_defs = true
-allow_untyped_defs = true
-allow_incomplete_defs = true
-
-[[tool.mypy.overrides]]
-module = "vcr"
-ignore_missing_imports = true
-
-[tool.pydantic-mypy]
-init_forbid_extra = true
-init_typed = true
+[tool.pyright]
+strict = [ "src/songlinker/**/*" ]
 
 [tool.ruff.lint]
 select = [

--- a/src/songlinker/link_api.py
+++ b/src/songlinker/link_api.py
@@ -1,8 +1,7 @@
-from collections import namedtuple
 from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import Enum
-from typing import Annotated, Self
+from typing import Annotated, NamedTuple, Self
 
 import httpx
 from opentelemetry import trace
@@ -27,7 +26,10 @@ UniqueEntityId = Annotated[
 
 NonEmptyString = Annotated[str, Field(min_length=1)]
 
-PlatformSpec = namedtuple("PlatformSpec", ["id", "name"])
+
+class PlatformSpec(NamedTuple):
+    id: str
+    name: str
 
 
 class Platform(Enum):
@@ -151,11 +153,11 @@ class LinkApi:
     def __enter__(self) -> Self:
         return self
 
-    def __exit__(  # type: ignore[no-untyped-def]
+    def __exit__(
         self,
-        exc_type,
-        exc_val,
-        exc_tb,
+        exc_type,  # pyright: ignore
+        exc_val,  # pyright: ignore
+        exc_tb,  # pyright: ignore
     ) -> None:
         self.close()
 

--- a/src/songlinker/link_api.py
+++ b/src/songlinker/link_api.py
@@ -1,3 +1,4 @@
+import types
 from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import Enum
@@ -155,9 +156,9 @@ class LinkApi:
 
     def __exit__(
         self,
-        exc_type,  # pyright: ignore
-        exc_val,  # pyright: ignore
-        exc_tb,  # pyright: ignore
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: types.TracebackType | None,
     ) -> None:
         self.close()
 

--- a/src/songlinker/telegram.py
+++ b/src/songlinker/telegram.py
@@ -20,7 +20,7 @@ def init(config: Config) -> None:
     if _API_KEY:
         raise RuntimeError("Tried to initialize telegram library multiple times")
 
-    _API_KEY = config.telegram_api_key
+    _API_KEY = config.telegram_api_key  # pyright: ignore[reportConstantRedefinition]
 
 
 def _build_url(method: str) -> str:

--- a/src/tests/link_api/test_link_api.py
+++ b/src/tests/link_api/test_link_api.py
@@ -15,9 +15,9 @@ def api_token(require_integration) -> str:
 
 
 @pytest.fixture()
-def link_api(api_token) -> LinkApi:  # type: ignore
+def link_api(api_token) -> LinkApi:  # pyright: ignore[reportInvalidTypeForm]
     with LinkApi(api_key=api_token) as api:
-        yield api
+        yield api  # pyright: ignore[reportReturnType]
 
 
 def test_context_manager__works(mocker):

--- a/uv.lock
+++ b/uv.lock
@@ -225,32 +225,12 @@ wheels = [
 ]
 
 [[package]]
-name = "mypy"
-version = "1.16.0"
+name = "nodeenv"
+version = "1.9.1"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mypy-extensions" },
-    { name = "pathspec" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d4/38/13c2f1abae94d5ea0354e146b95a1be9b2137a0d506728e0da037c4276f6/mypy-1.16.0.tar.gz", hash = "sha256:84b94283f817e2aa6350a14b4a8fb2a35a53c286f97c9d30f53b63620e7af8ab", size = 3323139, upload-time = "2025-05-29T13:46:12.532Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437, upload-time = "2024-06-04T18:44:11.171Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/9c/ca03bdbefbaa03b264b9318a98950a9c683e06472226b55472f96ebbc53d/mypy-1.16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a9e056237c89f1587a3be1a3a70a06a698d25e2479b9a2f57325ddaaffc3567b", size = 11059753, upload-time = "2025-05-29T13:18:18.167Z" },
-    { url = "https://files.pythonhosted.org/packages/36/92/79a969b8302cfe316027c88f7dc6fee70129490a370b3f6eb11d777749d0/mypy-1.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0b07e107affb9ee6ce1f342c07f51552d126c32cd62955f59a7db94a51ad12c0", size = 10073338, upload-time = "2025-05-29T13:19:48.079Z" },
-    { url = "https://files.pythonhosted.org/packages/14/9b/a943f09319167da0552d5cd722104096a9c99270719b1afeea60d11610aa/mypy-1.16.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c6fb60cbd85dc65d4d63d37cb5c86f4e3a301ec605f606ae3a9173e5cf34997b", size = 11827764, upload-time = "2025-05-29T13:46:04.47Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/64/ff75e71c65a0cb6ee737287c7913ea155845a556c64144c65b811afdb9c7/mypy-1.16.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7e32297a437cc915599e0578fa6bc68ae6a8dc059c9e009c628e1c47f91495d", size = 12701356, upload-time = "2025-05-29T13:35:13.553Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/ad/0e93c18987a1182c350f7a5fab70550852f9fabe30ecb63bfbe51b602074/mypy-1.16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:afe420c9380ccec31e744e8baff0d406c846683681025db3531b32db56962d52", size = 12900745, upload-time = "2025-05-29T13:17:24.409Z" },
-    { url = "https://files.pythonhosted.org/packages/28/5d/036c278d7a013e97e33f08c047fe5583ab4f1fc47c9a49f985f1cdd2a2d7/mypy-1.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:55f9076c6ce55dd3f8cd0c6fff26a008ca8e5131b89d5ba6d86bd3f47e736eeb", size = 9572200, upload-time = "2025-05-29T13:33:44.92Z" },
-    { url = "https://files.pythonhosted.org/packages/99/a3/6ed10530dec8e0fdc890d81361260c9ef1f5e5c217ad8c9b21ecb2b8366b/mypy-1.16.0-py3-none-any.whl", hash = "sha256:29e1499864a3888bca5c1542f2d7232c6e586295183320caa95758fc84034031", size = 2265773, upload-time = "2025-05-29T13:35:18.762Z" },
-]
-
-[[package]]
-name = "mypy-extensions"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314, upload-time = "2024-06-04T18:44:08.352Z" },
 ]
 
 [[package]]
@@ -398,15 +378,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pathspec"
-version = "0.12.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
-]
-
-[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -511,6 +482,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/7d/e09391c2eebeab681df2b74bfe6c43422fffede8dc74187b2b0bf6fd7571/pydantic_core-2.33.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:61c18fba8e5e9db3ab908620af374db0ac1baa69f0f32df4f61ae23f15e586ac", size = 1806162, upload-time = "2025-04-23T18:32:20.188Z" },
     { url = "https://files.pythonhosted.org/packages/f1/3d/847b6b1fed9f8ed3bb95a9ad04fbd0b212e832d4f0f50ff4d9ee5a9f15cf/pydantic_core-2.33.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95237e53bb015f67b63c91af7518a62a8660376a6a0db19b89acc77a4d6199f5", size = 1981560, upload-time = "2025-04-23T18:32:22.354Z" },
     { url = "https://files.pythonhosted.org/packages/6f/9a/e73262f6c6656262b5fdd723ad90f518f579b7bc8622e43a942eec53c938/pydantic_core-2.33.2-cp313-cp313t-win_amd64.whl", hash = "sha256:c2fc0a768ef76c15ab9238afa6da7f69895bb5d1ee83aeea2e3509af4472d0b9", size = 1935777, upload-time = "2025-04-23T18:32:25.088Z" },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.401"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/9a/7ab2b333b921b2d6bfcffe05a0e0a0bbeff884bd6fb5ed50cd68e2898e53/pyright-1.1.401.tar.gz", hash = "sha256:788a82b6611fa5e34a326a921d86d898768cddf59edde8e93e56087d277cc6f1", size = 3894193, upload-time = "2025-05-21T10:44:52.03Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/e6/1f908fce68b0401d41580e0f9acc4c3d1b248adcff00dfaad75cd21a1370/pyright-1.1.401-py3-none-any.whl", hash = "sha256:6fde30492ba5b0d7667c16ecaf6c699fab8d7a1263f6a18549e0b00bf7724c06", size = 5629193, upload-time = "2025-05-21T10:44:50.129Z" },
 ]
 
 [[package]]
@@ -646,7 +630,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "mypy" },
+    { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-mock" },
     { name = "pytest-recording" },
@@ -670,7 +654,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = "==1.16.*" },
+    { name = "pyright", specifier = "==1.1.401" },
     { name = "pytest", specifier = ">=8.0.0,<9.0.0" },
     { name = "pytest-mock", specifier = ">=3.11.1,<4.0.0" },
     { name = "pytest-recording", specifier = ">=0.13.0,<0.14.0" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Replaced mypy with pyright as the static type checker in development dependencies and configuration.
	- Updated linting commands and workflow to use pyright for type checking.
	- Removed all mypy and pydantic-mypy configuration, consolidating type checking under pyright.

- **Refactor**
	- Converted several internal data structures from namedtuple to NamedTuple with explicit type annotations for improved type safety.
	- Improved logging for unrecognized update and forward origin types.

- **Style**
	- Updated type ignore comments to use pyright-specific directives for better compatibility with the new type checker.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->